### PR TITLE
Update condition wait for Jenkins to started

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -68,10 +68,7 @@
     enabled: true
 
 - name: Wait for Jenkins to start up before proceeding.
-  command:
-    "curl -D - --silent --max-time 5 \
-    http://{{ jenkins_hostname }}:{{ jenkins_http_port }}\
-    {{ jenkins_url_prefix }}/cli/"
+  command: "curl -D - --silent --max-time 5 http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/"
   args:
     warn: false
   register: result
@@ -83,6 +80,12 @@
   delay: "{{ jenkins_connection_delay }}"
   changed_when: false
   check_mode: false
+  ignore_errors: true
+  register: wait_result
+
+- debug:
+    var: wait_result
+
 
 - name: Check if jenkins_init_file exists.
   stat:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -73,9 +73,9 @@
     warn: false
   register: result
   until: >
-    (result.stdout is defined and "403 Forbidden" in result.stdout)
-    or (result.stdout is defined and "200 OK" in result.stdout)
-    and (result.stdout is defined and "Please wait while" not in result.stdout)
+    (result.stdout_lines | join('') | regex_search("403 Forbidden"))
+    or (result.stdout_lines | join('') | regex_search("200 OK"))
+    and not (result.stdout_lines | join('') | regex_search("Please wait while"))
   retries: "{{ jenkins_connection_retries }}"
   delay: "{{ jenkins_connection_delay }}"
   changed_when: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -68,24 +68,17 @@
     enabled: true
 
 - name: Wait for Jenkins to start up before proceeding.
-  command: "curl -D - --silent --max-time 5 http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/"
-  args:
-    warn: false
-  register: result
+  ansible.builtin.command: "curl -D - --silent --max-time 5 http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/"
+  register: wait_result
   until: >
-    (result is defined and result.stdout_lines | join('') | regex_search("403 Forbidden"))
-    or (result is defined and result.stdout_lines | join('') | regex_search("200 OK"))
-    and not (result is defined and result.stdout_lines | join('') | regex_search("Please wait while"))
+    (wait_result.stdout is defined and wait_result.stdout | regex_search("403 Forbidden")) or 
+    (wait_result.stdout is defined and wait_result.stdout | regex_search("200 OK")) and
+    not wait_result.stdout | regex_search("Please wait while")
   retries: "2"
   delay: "{{ jenkins_connection_delay }}"
   changed_when: false
   check_mode: false
   ignore_errors: true
-  register: wait_result
-
-- debug:
-    var: wait_result
-
 
 - name: Check if jenkins_init_file exists.
   stat:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -73,10 +73,10 @@
     warn: false
   register: result
   until: >
-    (result.stdout_lines | join('') | regex_search("403 Forbidden"))
-    or (result.stdout_lines | join('') | regex_search("200 OK"))
-    and not (result.stdout_lines | join('') | regex_search("Please wait while"))
-  retries: "{{ jenkins_connection_retries }}"
+    (result is defined and result.stdout_lines | join('') | regex_search("403 Forbidden"))
+    or (result is defined and result.stdout_lines | join('') | regex_search("200 OK"))
+    and not (result is defined and result.stdout_lines | join('') | regex_search("Please wait while"))
+  retries: "2"
   delay: "{{ jenkins_connection_delay }}"
   changed_when: false
   check_mode: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -76,9 +76,9 @@
     warn: false
   register: result
   until: >
-    (result.stdout.find("403 Forbidden") != -1)
-    or (result.stdout.find("200 OK") != -1)
-    and (result.stdout.find("Please wait while") == -1)
+    (result.stdout is defined and "403 Forbidden" in result.stdout)
+    or (result.stdout is defined and "200 OK" in result.stdout)
+    and (result.stdout is defined and "Please wait while" not in result.stdout)
   retries: "{{ jenkins_connection_retries }}"
   delay: "{{ jenkins_connection_delay }}"
   changed_when: false

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -34,19 +34,15 @@
 - name: Force Restart and wait handlers
   meta: flush_handlers
 
-- name: wait jenkins
-  command:
-    "curl -D - --silent --max-time 5 \
-    http://{{ jenkins_hostname }}:{{ jenkins_http_port }}\
-    {{ jenkins_url_prefix }}/cli/"
-  args:
-    warn: false
-  register: result
+- name: Wait  Jenkins
+  ansible.builtin.command: "curl -D - --silent --max-time 5 http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/"
+  register: wait_result
   until: >
-    (result.stdout.find("403 Forbidden") != -1)
-    or (result.stdout.find("200 OK") != -1)
-    and (result.stdout.find("Please wait while") == -1)
-  retries: "{{ jenkins_connection_retries }}"
+    (wait_result.stdout is defined and wait_result.stdout | regex_search("403 Forbidden")) or 
+    (wait_result.stdout is defined and wait_result.stdout | regex_search("200 OK")) and
+    not wait_result.stdout | regex_search("Please wait while")
+  retries: "2"
   delay: "{{ jenkins_connection_delay }}"
   changed_when: false
   check_mode: false
+  ignore_errors: true


### PR DESCRIPTION
<!-- Please use the 'security' label if this is a security-related change. -->

#### What this PR does / Why we need it
Update condition wait for Jenkins to started, the old command is out dated
#### Which related issue this PR fixes
https://nfq-asia.atlassian.net/browse/

#### Special notes for your reviewer

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->
-   [ ] run `yamllint` on the directories you changed to rewrite Ansible configuration files to a canonical format and style.
-   [ ] Variables are documented in the README.md
