### PR TITLE
Update apt key for jenkins

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 jenkins_package_state: present
 __jenkins_repo_url: deb https://pkg.jenkins.io/debian-stable binary/
-__jenkins_repo_key_url: https://pkg.jenkins.io/debian-stable/jenkins.io.key
+__jenkins_repo_key_url: https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key
 __jenkins_pkg_url: https://pkg.jenkins.io/debian-stable/binary
 
 jenkins_connection_delay: 5


### PR DESCRIPTION
<!-- Please use the 'security' label if this is a security-related change. -->

#### What this PR does / Why we need it
This PR aims at updating the apt key url of jenkins on linux.
#### Which related issue this PR fixes

#### Special notes for your reviewer

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields.] -->
-   [ ] run `yamllint` on the directories you changed to rewrite Ansible configuration files to a canonical format and style.
-   [ ] Variables are documented in the README.md
